### PR TITLE
Some changes + fixes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,3 @@
 seb! <sebi@sebi.one.pl>
+
+bryjamus <bryjamus@gmail.com>

--- a/provision/powershell/extend-PATH-environment-variable.ps1
+++ b/provision/powershell/extend-PATH-environment-variable.ps1
@@ -1,0 +1,31 @@
+# file    : extend-PATH-environment-variable.ps1
+# author  : bryjamus <bryjamus@gmail.com>
+# license : MIT
+
+# This script:
+# * Adds to %PTH% environment variable paths
+
+Function AddTo-SystemPath {
+  Param([array] $PathToAdd)
+  $VerifiedPathsToAdd = $Null
+  Foreach ($Path in $PathToAdd) {
+    if ($env:Path -like "*$Path*") {
+      Write-Host "Currnet item in path is: $Path"
+      Write-Host "$Path already exists in Path statement"
+    }
+    else {
+      $VerifiedPathsToAdd += ";$Path"
+      Write-Host "`$VerifiedPathsToAdd updated to contain: $Path"
+    }         
+
+    if($VerifiedPathsToAdd -ne $null) {
+      Write-Host "`$VerifiedPathsToAdd contains: $verifiedPathsToAdd"
+      Write-Host "Adding $Path to Path statement now..."
+      [Environment]::SetEnvironmentVariable("Path",$env:Path + $VerifiedPathsToAdd,"Process")
+    }
+  }
+}
+
+$Path = Join-Path $ENV:UserProfile 'bin'
+
+AddTo-SystemPath(@($Path))

--- a/provision/powershell/sysroot-protected.ps1
+++ b/provision/powershell/sysroot-protected.ps1
@@ -10,6 +10,8 @@
 # See also: utils\Encrypt-Json.ps1
 
 $secureKey = 'C:\vagrant\.vagrant\my-private.key'
+$bytes = [System.IO.File]::ReadAllBytes($secureKey)
+[System.Array]::Resize([ref] $bytes, 32);
 
 Get-ChildItem                              -Path 'C:\vagrant\sysroot-protected' `
                                            -Recurse -File                       `
@@ -17,7 +19,7 @@ Get-ChildItem                              -Path 'C:\vagrant\sysroot-protected' 
     | ForEach-Object                                                            `
 {
     $secureString = Get-Content $_                                              `
-                  | ConvertTo-SecureString -Key (Get-Content $secureKey)
+                  | ConvertTo-SecureString -Key ($bytes)
     $destination  = $_.Replace("vagrant\sysroot-protected\","")
 
     New-Item -Path "$($destination)" -ItemType File -Force

--- a/utils/Encrypt-Json.ps1
+++ b/utils/Encrypt-Json.ps1
@@ -14,6 +14,9 @@
 #
 # This is not a cmdlet.
 
+$bytes = [System.IO.File]::ReadAllBytes(".\.vagrant\my-private.key")
+[System.Array]::Resize([ref] $bytes, 32);
+
 Get-Content $args[0]                -Raw                                          `
    | Select-Object                                                                `
            @{ Name='Oneline';                                                     `
@@ -21,4 +24,4 @@ Get-Content $args[0]                -Raw                                        
    | Select-Object                  -ExpandProperty Oneline                       `
    | ConvertTo-SecureString         -AsPlainText                                  `
                                     -Force                                        `
-   | ConvertFrom-SecureString       -Key (Get-Content .\.vagrant\my-private.key)
+   | ConvertFrom-SecureString       -Key ($bytes)


### PR DESCRIPTION
1. Fix my private key length - when file was smaller or larger than 32 bytes power shell encryption/decryption fail
2. Windows Credential Manager path (babun install it in %USERPROFILE%\bin) was not added to %PATH% environment variable. I add power shell script which do it.
